### PR TITLE
Ensure history table schema matches initializer

### DIFF
--- a/src/main/java/org/example/db/SearchHistoryDao.java
+++ b/src/main/java/org/example/db/SearchHistoryDao.java
@@ -16,6 +16,7 @@ public class SearchHistoryDao {
             // Створюємо таблицю, якщо її ще немає
             ddl.executeUpdate(
                     "CREATE TABLE IF NOT EXISTS search_entry (" +
+                            "  id INTEGER PRIMARY KEY AUTOINCREMENT," +
                             "  query TEXT NOT NULL" +
                             ")"
             );


### PR DESCRIPTION
## Summary
- align `SearchHistoryDao` DDL with `DatabaseInitializer`
- the table now always includes an auto-increment `id` column

## Testing
- `mvn -q test` *(fails: could not download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68603689fc0c8325847fddf9492fcd85