### PR TITLE
Add acceptance test using Consul

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,20 @@
             <version>5.4.0</version>
             <scope>test</scope>
         </dependency>
+
+        <!-- Testcontainers for acceptance tests -->
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>testcontainers</artifactId>
+            <version>1.19.6</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>1.19.6</version>
+            <scope>test</scope>
+        </dependency>
         <!-- Quarkus Mockito extension для @InjectMock -->
 
         <dependency>

--- a/src/test/java/org/example/acceptance/ConsulAcceptanceTest.java
+++ b/src/test/java/org/example/acceptance/ConsulAcceptanceTest.java
@@ -1,0 +1,36 @@
+package org.example.acceptance;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.quarkus.test.junit.QuarkusTestResource;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.DockerClientFactory;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+
+@QuarkusTest
+@QuarkusTestResource(ConsulTestResource.class)
+public class ConsulAcceptanceTest {
+
+    @BeforeAll
+    static void checkDocker() {
+        Assumptions.assumeTrue(DockerClientFactory.instance().isDockerAvailable());
+    }
+
+    @Test
+    void testIndexingFromConsul() {
+        given().when().get("/reindex").then().statusCode(anyOf(is(200), is(302)));
+
+        given()
+                .queryParam("q", "foo")
+                .when().get("/api/search")
+                .then()
+                .statusCode(200)
+                .body("[0].key", equalTo("foo"));
+    }
+}
+

--- a/src/test/java/org/example/acceptance/ConsulTestResource.java
+++ b/src/test/java/org/example/acceptance/ConsulTestResource.java
@@ -1,0 +1,56 @@
+package org.example.acceptance;
+
+import io.quarkus.test.common.QuarkusTestResourceLifecycleManager;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+public class ConsulTestResource implements QuarkusTestResourceLifecycleManager {
+    private GenericContainer<?> consul;
+
+    @Override
+    public Map<String, String> start() {
+        consul = new GenericContainer<>(DockerImageName.parse("hashicorp/consul:1.17"))
+                .withExposedPorts(8500);
+        consul.start();
+
+        String host = consul.getHost();
+        int port = consul.getMappedPort(8500);
+
+        putKv(host, port, "foo", "bar");
+        putKv(host, port, "hello", "world");
+
+        Map<String, String> props = new HashMap<>();
+        props.put("CONSUL_HOST", host);
+        props.put("CONSUL_PORT", Integer.toString(port));
+        return props;
+    }
+
+    private static void putKv(String host, int port, String key, String value) {
+        try {
+            URL url = new URL("http://" + host + ":" + port + "/v1/kv/" + key);
+            HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+            conn.setRequestMethod("PUT");
+            conn.setDoOutput(true);
+            try (OutputStream os = conn.getOutputStream()) {
+                os.write(value.getBytes(StandardCharsets.UTF_8));
+            }
+            conn.getInputStream().close();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (consul != null) {
+            consul.stop();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- integrate Testcontainers for acceptance testing
- add Consul test resource that starts a Consul container and loads sample KV data
- implement acceptance test verifying the application indexes Consul data

## Testing
- `mvn -q test` *(fails: could not download Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68603dfeb4588325bbc40ffa4ae9d2f6